### PR TITLE
Block deserialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /target
 **/*.rs.bk
 **/node_modules
+**/dist
 package-lock.json
 Cargo.lock
 bin/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ chain-crypto = { path = "./chain-libs/chain-crypto" }
 chain-core = { path = "./chain-libs/chain-core" }
 serde = { version = "1.0.93", features = ["derive"] }
 bech32 = "0.6"
+js-sys = "0.3.24"
 
 # The default can't be compiled to wasm, so it's necessary to use either the 'nightly'
 # feature or this one

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ use chain_impl_mockchain as chain;
 use crypto::bech32::Bech32 as _;
 use std::str::FromStr;
 use wasm_bindgen::prelude::*;
+use std::convert::TryFrom;
 
 #[wasm_bindgen]
 pub struct PrivateKey(key::EitherEd25519SecretKey);
@@ -98,7 +99,7 @@ impl From<tx::Transaction<chain_addr::Address, certificate::Certificate>> for Tr
 
 #[wasm_bindgen]
 impl Transaction {
-    pub fn id(&self) -> TransactionId {
+    pub fn id(&self) -> TransactionSignDataHash {
         match &self.0 {
             EitherTransaction::TransactionWithoutCertificate(tx) => tx.hash(),
             EitherTransaction::TransactionWithCertificate(tx) => tx.hash(),
@@ -260,7 +261,7 @@ impl TransactionBuilder {
     }
 
     #[wasm_bindgen]
-    pub fn get_txid(&self) -> TransactionId {
+    pub fn get_txid(&self) -> TransactionSignDataHash {
         match &self.0 {
             EitherTransactionBuilder::TransactionBuilderNoExtra(builder) => {
                 builder.tx.hash().into()
@@ -321,7 +322,7 @@ impl TransactionFinalizer {
             .map_err(|e| JsValue::from_str(&format!("{}", e)))
     }
 
-    pub fn get_txid(&self) -> TransactionId {
+    pub fn get_txid(&self) -> TransactionSignDataHash {
         self.0.get_txid().into()
     }
 
@@ -344,7 +345,7 @@ impl From<txbuilder::GeneratedTransaction> for GeneratedTransaction {
 
 #[wasm_bindgen]
 impl GeneratedTransaction {
-    pub fn id(&self) -> TransactionId {
+    pub fn id(&self) -> TransactionSignDataHash {
         match &self.0 {
             chain::txbuilder::GeneratedTransaction::Type1(auth) => auth.transaction.hash(),
             chain::txbuilder::GeneratedTransaction::Type2(auth) => auth.transaction.hash(),
@@ -354,28 +355,30 @@ impl GeneratedTransaction {
 }
 
 #[wasm_bindgen]
-pub struct TransactionId(tx::TransactionId);
+pub struct TransactionSignDataHash(tx::TransactionSignDataHash);
 
 #[wasm_bindgen]
-impl TransactionId {
-    pub fn from_bytes(bytes: &[u8]) -> TransactionId {
-        tx::TransactionId::hash_bytes(bytes).into()
+impl TransactionSignDataHash {
+    pub fn from_bytes(bytes: &[u8]) -> Result<TransactionSignDataHash, JsValue> {
+        tx::TransactionSignDataHash::try_from(bytes)
+        .map_err(|e| JsValue::from_str(&format!("{}", e)))
+        .map(|digest| digest.into())
     }
 
-    pub fn from_hex(input: &str) -> Result<TransactionId, JsValue> {
-        tx::TransactionId::from_str(input)
+    pub fn from_hex(input: &str) -> Result<TransactionSignDataHash, JsValue> {
+        tx::TransactionSignDataHash::from_str(input)
             .map_err(|e| JsValue::from_str(&format!("{:?}", e)))
-            .map(TransactionId)
+            .map(TransactionSignDataHash)
     }
 
     pub fn as_bytes(&self) -> Vec<u8> {
-        self.0.serialize_as_vec().unwrap()
+        self.0.as_ref().to_vec()
     }
 }
 
-impl From<tx::TransactionId> for TransactionId {
-    fn from(txid: tx::TransactionId) -> TransactionId {
-        TransactionId(txid)
+impl From<tx::TransactionSignDataHash> for TransactionSignDataHash {
+    fn from(txid: tx::TransactionSignDataHash) -> TransactionSignDataHash {
+        TransactionSignDataHash(txid)
     }
 }
 
@@ -427,9 +430,9 @@ pub struct UtxoPointer(tx::UtxoPointer);
 
 #[wasm_bindgen]
 impl UtxoPointer {
-    pub fn new(tx_id: TransactionId, output_index: u8, value: u64) -> UtxoPointer {
+    pub fn new(fragment_id: FragmentId, output_index: u8, value: u64) -> UtxoPointer {
         UtxoPointer(tx::UtxoPointer {
-            transaction_id: tx_id.0,
+            transaction_id: fragment_id.0,
             output_index,
             value: value::Value(value),
         })
@@ -622,7 +625,7 @@ pub struct Witness(tx::Witness);
 impl Witness {
     pub fn for_utxo(
         genesis_hash: Hash,
-        transaction_id: TransactionId,
+        transaction_id: TransactionSignDataHash,
         secret_key: PrivateKey,
     ) -> Witness {
         Witness(tx::Witness::new_utxo(
@@ -634,7 +637,7 @@ impl Witness {
 
     pub fn for_account(
         genesis_hash: Hash,
-        transaction_id: TransactionId,
+        transaction_id: TransactionSignDataHash,
         secret_key: PrivateKey,
         account_spending_counter: SpendingCounter,
     ) -> Witness {
@@ -679,20 +682,20 @@ impl SpendingCounter {
 }
 
 #[wasm_bindgen]
-pub struct Message(chain::message::Message);
+pub struct Fragment(chain::fragment::Fragment);
 
 #[wasm_bindgen]
-impl Message {
-    pub fn from_generated_transaction(tx: GeneratedTransaction) -> Message {
+impl Fragment {
+    pub fn from_generated_transaction(tx: GeneratedTransaction) -> Fragment {
         let msg = match tx.0 {
             chain::txbuilder::GeneratedTransaction::Type1(auth) => {
-                chain::message::Message::Transaction(auth)
+                chain::fragment::Fragment::Transaction(auth)
             }
             chain::txbuilder::GeneratedTransaction::Type2(auth) => {
-                chain::message::Message::Certificate(auth)
+                chain::fragment::Fragment::Certificate(auth)
             }
         };
-        Message(msg)
+        Fragment(msg)
     }
 
     pub fn as_bytes(&self) -> Result<Vec<u8>, JsValue> {
@@ -703,25 +706,13 @@ impl Message {
     }
 }
 
-//this is useful for debugging, I'm not sure it is a good idea to have it here
-//also, the 'hex' module in chain_crypto is private, so I cannot use that
-
 #[wasm_bindgen]
-pub fn uint8array_to_hex(input: JsValue) -> Result<String, JsValue> {
-    //For some reason JSON.stringify serializes Uint8Array as objects instead of arrays
-    let input_array: std::collections::BTreeMap<usize, u8> = input
-        .into_serde()
-        .map_err(|e| JsValue::from_str(&format!("{}", e)))?;
+pub struct FragmentId(chain::fragment::FragmentId);
 
-    let mut v = Vec::with_capacity(input_array.len() * 2);
-
-    const ALPHABET: &'static [u8] = b"0123456789abcdef";
-    for &byte in input_array.values() {
-        v.push(ALPHABET[(byte >> 4) as usize]);
-        v.push(ALPHABET[(byte & 0xf) as usize]);
+impl From<chain::fragment::FragmentId> for FragmentId {
+    fn from(fragment_id: chain::fragment::FragmentId) -> FragmentId {
+        FragmentId(fragment_id)
     }
-
-    String::from_utf8(v).map_err(|e| JsValue::from_str(&format!("{}", e)))
 }
 
 // When the `wee_alloc` feature is enabled, use `wee_alloc` as the global

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -715,6 +715,27 @@ impl From<chain::fragment::FragmentId> for FragmentId {
     }
 }
 
+//this is useful for debugging, I'm not sure it is a good idea to have it here
+//also, the 'hex' module in chain_crypto is private, so I cannot use that
+
+#[wasm_bindgen]
+pub fn uint8array_to_hex(input: JsValue) -> Result<String, JsValue> {
+    //For some reason JSON.stringify serializes Uint8Array as objects instead of arrays
+    let input_array: std::collections::BTreeMap<usize, u8> = input
+        .into_serde()
+        .map_err(|e| JsValue::from_str(&format!("{}", e)))?;
+
+    let mut v = Vec::with_capacity(input_array.len() * 2);
+
+    const ALPHABET: &'static [u8] = b"0123456789abcdef";
+    for &byte in input_array.values() {
+        v.push(ALPHABET[(byte >> 4) as usize]);
+        v.push(ALPHABET[(byte & 0xf) as usize]);
+    }
+
+    String::from_utf8(v).map_err(|e| JsValue::from_str(&format!("{}", e)))
+}
+
 // When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
 // allocator.
 #[cfg(feature = "wee_alloc")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,13 +54,13 @@ pub struct Address(chain_addr::Address);
 impl Address {
     //XXX: Maybe this should be from_bech32?
     pub fn from_string(s: &str) -> Result<Address, JsValue> {
-        chain_addr::AddressReadable::from_string(s)
+        chain_addr::AddressReadable::from_string_anyprefix(s)
             .map(|address_readable| Address(address_readable.to_address()))
             .map_err(|e| JsValue::from_str(&format! {"{:?}", e}))
     }
 
-    pub fn to_string(&self) -> String {
-        format!("{}", chain_addr::AddressReadable::from_address(&self.0))
+    pub fn to_string(&self, prefix: &str) -> String {
+        format!("{}", chain_addr::AddressReadable::from_address(prefix, &self.0))
     }
 }
 

--- a/tests/index.js
+++ b/tests/index.js
@@ -99,3 +99,37 @@ makeTransaction({
     poolId: '541db50349e2bc1a5b1a73939b9d86fc45067117cc930c36afbb6fb0a9329d41'
   }
 });
+
+function hexStringToBytes(string) {
+  const bytes = [];
+  for (let c = 0; c < string.length; c += 2)
+    bytes.push(parseInt(string.substr(c, 2), 16));
+  return Uint8Array.from(bytes);
+}
+
+function toHexString(byteArray) {
+  return Array.from(byteArray, function (byte) {
+    return `0${(byte & 0xff).toString(16)}`.slice(-2);
+  }).join('');
+}
+
+getBlockMessages(
+  {
+    binaryBlock: "02b600020000009800000000000001690000000acf5d01183ef5ed50d3fedf3e96b1a45cd87bc0c5902092f0de437319cc45d9c61a6809320426eb9be554c73226ae6d635463d1e6fdf3617db2ca9ac4a028da2234d115eed4fea1b61dee0630255139a7600f60cb885ea46d469e9925715aa7f94ea9b98611b5371f9ec378b2dae2d9050f1373b60cd9abf34e497527b6844678eb7c5507f1b77758c203d4553382f95e5110eec2489217bf74a25b9bb3282e0df79ab144a8e1278bc46a0bb28df37c3121b925caa0b601b44f77c47a037ec00800000000823a4d7d530bbdde7dbd684feff4c2f81b03fbd576554011e39919a3606fdbb5469aa1dcf468213f8a77c19670a06570d25d8e379572b6cdcf87235a503e180561bc5f729decb44a15e339f342769ad13a4c2d6508d96fc195833850304964d4c1f040bfd229053e2db491a55596e1d0de9d604ffb6432a0a55d395d7eb85dd50bf04ab074d63fa3e57d0a3b3debbd2e5c146edca18b3acd96196874a8aeae3f47ba546e517735e5ff6d2e3c4ae2784b4faad10f8e5f885f717691e3be16f65c90357ec8cc9a5767abb3038f07880ae06084663622ddb8635c641a826668b31e97427c3b837acbf4419f4d90b413e9b8c50ca5f7f8796eeadd38959566425669c8f5d6ff19182745e7d80b472c814657cd0761372a96965668e89df2e58f0d8c099a49e7f1185393790442aeb74759f5809b13ff5be062104de417935ddb7f971f06b2886d224fa15570e908419c25b21d46f37c10a16706095da2fa94e4e6ecae9dc98d1b2ab9c62d6db3e2447fe2e970c676244259273f23809bd6f5b8c89847a8d1712f3b4fc6753b23eb60fc81f6e958e3b3d6324efa43177ac10dc8440c8cb016a275b5e7ec9b1266b21685e599bdb76885bcccd264fb2ed15f0dd7617701e7f051d5650a317bbd5a59febd2faa461a4d9a6168b606176fcfdf4984d97b0096020101ff000000000000271a975629a823988d0f43e66fdce0ab7d825e3a870f1b60455e83dd433eb74b9d0e85b48e462477a2d1e9e9566e1d1b3b4262f1d4a3161544586998d3ce112fd930890000000000002710026f198f4cda3f0196d91910711058abaa5a2539661a2c7308d1b196b1f86f6d9e73034ff273782670dac048d302293392ed4aaab5ebc5b09c48dbc687353fdc02",
+    id: "c0a74e7b5ee427101c19cc18d3863a8822f1b4bf977648bf4b6a7b288fd9214b",
+  }
+);
+
+async function getBlockMessages(args) {
+  const { binaryBlock, id } = args;
+  const {
+    Block,
+    Message,
+  } = await rust;
+
+  const block = Block.from_bytes(hexStringToBytes(binaryBlock));
+  console.log(toHexString(block.id().as_bytes()));
+  console.log(block.messages().size());
+  console.log(block.messages().get_by_index(0).is_transaction());
+  console.log(toHexString(block.messages().get_by_index(0).get_transaction().id().as_bytes()));
+}

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,3 +1,5 @@
+import { get } from 'https';
+
 /* eslint-disable promise/always-return */
 /* global BigInt */
 import { expect } from 'chai';
@@ -17,12 +19,13 @@ async function makeTransaction(args) {
     PublicKey,
     Certificate,
     TransactionFinalizer,
-    Message,
+    Fragment,
     PrivateKey,
     Witness,
     SpendingCounter,
     Hash,
     Account,
+    // eslint-disable-next-line camelcase
     uint8array_to_hex
   } = await rust;
   const txbuilder = new TransactionBuilder();
@@ -71,7 +74,7 @@ async function makeTransaction(args) {
 
   const signedTx = finalizer.build();
 
-  const message = Message.from_generated_transaction(signedTx);
+  const message = Fragment.from_generated_transaction(signedTx);
 
   expect(uint8array_to_hex(message.as_bytes())).to.eql(
     '0143030102ff00000000000003e8cbc7ccdb9a51eea4e4c7088353c1a1902dcf685f739194dc9faff26b7f42e21905263a058b2e6817bcb058e1734da381a995e3335c3e150dd2d621b3c136557aa700000000000001f405cbc7ccdb9a51eea4e4c7088353c1a1902dcf685f739194dc9faff26b7f42e21900000000000001c701cbc7ccdb9a51eea4e4c7088353c1a1902dcf685f739194dc9faff26b7f42e219541db50349e2bc1a5b1a73939b9d86fc45067117cc930c36afbb6fb0a9329d41010040faef2a78b53511b598b9484108fff109d1a098558e037c6c04246a7b78557eccfb7f38a774dcf584bb68c99db205f6e95ffde4c42696a8b0d730030aaacad70402c8414c567e866f73a5b89ae434c5f38cb6dc4dca2a9c2f18026aa0123eaa0220aa0ece26a1373cbb8a3568755580835e47ffc33d38a906c359a2c038b15cd709'
@@ -107,29 +110,53 @@ function hexStringToBytes(string) {
   return Uint8Array.from(bytes);
 }
 
-function toHexString(byteArray) {
-  return Array.from(byteArray, function (byte) {
-    return `0${(byte & 0xff).toString(16)}`.slice(-2);
-  }).join('');
-}
-
-getBlockMessages(
-  {
-    binaryBlock: "02b600020000009800000000000001690000000acf5d01183ef5ed50d3fedf3e96b1a45cd87bc0c5902092f0de437319cc45d9c61a6809320426eb9be554c73226ae6d635463d1e6fdf3617db2ca9ac4a028da2234d115eed4fea1b61dee0630255139a7600f60cb885ea46d469e9925715aa7f94ea9b98611b5371f9ec378b2dae2d9050f1373b60cd9abf34e497527b6844678eb7c5507f1b77758c203d4553382f95e5110eec2489217bf74a25b9bb3282e0df79ab144a8e1278bc46a0bb28df37c3121b925caa0b601b44f77c47a037ec00800000000823a4d7d530bbdde7dbd684feff4c2f81b03fbd576554011e39919a3606fdbb5469aa1dcf468213f8a77c19670a06570d25d8e379572b6cdcf87235a503e180561bc5f729decb44a15e339f342769ad13a4c2d6508d96fc195833850304964d4c1f040bfd229053e2db491a55596e1d0de9d604ffb6432a0a55d395d7eb85dd50bf04ab074d63fa3e57d0a3b3debbd2e5c146edca18b3acd96196874a8aeae3f47ba546e517735e5ff6d2e3c4ae2784b4faad10f8e5f885f717691e3be16f65c90357ec8cc9a5767abb3038f07880ae06084663622ddb8635c641a826668b31e97427c3b837acbf4419f4d90b413e9b8c50ca5f7f8796eeadd38959566425669c8f5d6ff19182745e7d80b472c814657cd0761372a96965668e89df2e58f0d8c099a49e7f1185393790442aeb74759f5809b13ff5be062104de417935ddb7f971f06b2886d224fa15570e908419c25b21d46f37c10a16706095da2fa94e4e6ecae9dc98d1b2ab9c62d6db3e2447fe2e970c676244259273f23809bd6f5b8c89847a8d1712f3b4fc6753b23eb60fc81f6e958e3b3d6324efa43177ac10dc8440c8cb016a275b5e7ec9b1266b21685e599bdb76885bcccd264fb2ed15f0dd7617701e7f051d5650a317bbd5a59febd2faa461a4d9a6168b606176fcfdf4984d97b0096020101ff000000000000271a975629a823988d0f43e66fdce0ab7d825e3a870f1b60455e83dd433eb74b9d0e85b48e462477a2d1e9e9566e1d1b3b4262f1d4a3161544586998d3ce112fd930890000000000002710026f198f4cda3f0196d91910711058abaa5a2539661a2c7308d1b196b1f86f6d9e73034ff273782670dac048d302293392ed4aaab5ebc5b09c48dbc687353fdc02",
-    id: "c0a74e7b5ee427101c19cc18d3863a8822f1b4bf977648bf4b6a7b288fd9214b",
-  }
-);
+getBlockMessages({
+  binaryBlock:
+    '02b600020000009800000000000001690000000acf5d01183ef5ed50d3fedf3e96b1a45cd87bc0c5902092f0de437319cc45d9c61a6809320426eb9be554c73226ae6d635463d1e6fdf3617db2ca9ac4a028da2234d115eed4fea1b61dee0630255139a7600f60cb885ea46d469e9925715aa7f94ea9b98611b5371f9ec378b2dae2d9050f1373b60cd9abf34e497527b6844678eb7c5507f1b77758c203d4553382f95e5110eec2489217bf74a25b9bb3282e0df79ab144a8e1278bc46a0bb28df37c3121b925caa0b601b44f77c47a037ec00800000000823a4d7d530bbdde7dbd684feff4c2f81b03fbd576554011e39919a3606fdbb5469aa1dcf468213f8a77c19670a06570d25d8e379572b6cdcf87235a503e180561bc5f729decb44a15e339f342769ad13a4c2d6508d96fc195833850304964d4c1f040bfd229053e2db491a55596e1d0de9d604ffb6432a0a55d395d7eb85dd50bf04ab074d63fa3e57d0a3b3debbd2e5c146edca18b3acd96196874a8aeae3f47ba546e517735e5ff6d2e3c4ae2784b4faad10f8e5f885f717691e3be16f65c90357ec8cc9a5767abb3038f07880ae06084663622ddb8635c641a826668b31e97427c3b837acbf4419f4d90b413e9b8c50ca5f7f8796eeadd38959566425669c8f5d6ff19182745e7d80b472c814657cd0761372a96965668e89df2e58f0d8c099a49e7f1185393790442aeb74759f5809b13ff5be062104de417935ddb7f971f06b2886d224fa15570e908419c25b21d46f37c10a16706095da2fa94e4e6ecae9dc98d1b2ab9c62d6db3e2447fe2e970c676244259273f23809bd6f5b8c89847a8d1712f3b4fc6753b23eb60fc81f6e958e3b3d6324efa43177ac10dc8440c8cb016a275b5e7ec9b1266b21685e599bdb76885bcccd264fb2ed15f0dd7617701e7f051d5650a317bbd5a59febd2faa461a4d9a6168b606176fcfdf4984d97b0096020101ff000000000000271a975629a823988d0f43e66fdce0ab7d825e3a870f1b60455e83dd433eb74b9d0e85b48e462477a2d1e9e9566e1d1b3b4262f1d4a3161544586998d3ce112fd930890000000000002710026f198f4cda3f0196d91910711058abaa5a2539661a2c7308d1b196b1f86f6d9e73034ff273782670dac048d302293392ed4aaab5ebc5b09c48dbc687353fdc02',
+  id: 'c0a74e7b5ee427101c19cc18d3863a8822f1b4bf977648bf4b6a7b288fd9214b'
+});
 
 async function getBlockMessages(args) {
   const { binaryBlock, id } = args;
-  const {
-    Block,
-    Message,
-  } = await rust;
+  const { Block, Hash } = await rust;
 
   const block = Block.from_bytes(hexStringToBytes(binaryBlock));
-  console.log(toHexString(block.id().as_bytes()));
-  console.log(block.messages().size());
-  console.log(block.messages().get_by_index(0).is_transaction());
-  console.log(toHexString(block.messages().get_by_index(0).get_transaction().id().as_bytes()));
+
+  expect(block.id().as_bytes()).to.eql(Hash.from_hex(id).as_bytes());
+  expect(block.fragments().size()).to.eql(1);
+  expect(
+    block
+      .fragments()
+      .get_by_index(0)
+      .is_transaction()
+  ).to.eql(true);
+
+  const transaction = block
+    .fragments()
+    .get_by_index(0)
+    .get_transaction()
+    .transaction();
+
+  const inputs = transaction.inputs();
+  const outputs = transaction.outputs();
+
+  expect(inputs.size()).to.eql(1);
+  expect(outputs.size()).to.eql(1);
+
+  const input = inputs.get(0);
+  expect(input.get_type()).to.eql('Account');
+
+  expect(
+    input
+      .get_account()
+      .to_address()
+      .to_string('ca')
+  ).to.eql('ca1qkt4v2dgywvg6r6ruehaec9t0kp9uw58pudkq327s0w5x04hfwwsus6xplp');
+
+  const output = outputs.get(0);
+
+  expect(output.address().to_string('ca')).to.eql(
+    'ca1sk6gu33yw73dr60f2ehp6xemgf30r49rzc25gkrfnrfuuyf0mycgjvef0dw'
+  );
+  expect(output.value().to_number()).to.equal(BigInt(10000));
 }


### PR DESCRIPTION
branched from #7 

- Fix some errors in existing example
- Add block deserialization and a bunch of observers over those
    - Get fragments
    - Get transaction from fragment
        - Get inputs (utxo or account, and value)
        - Get outputs (address, value)
- Use assertions in the js tests/examples

For the collections (e.g. get_fragments from block, inputs...), I used some wrappers around Vec (as it is not possible to just return Vec<T>), this may not be the best or most efficient way, as it requires copying a few things, but I don't see an easier way of achieving that.