### PR TITLE
Add javascript documentation system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Cargo.lock
 bin/
 pkg/
 wasm-pack.log
+docs/

--- a/README.md
+++ b/README.md
@@ -195,3 +195,7 @@ npm run serve
 ```
 
 Go to `http://127.0.0.1:8080/` to see the results.
+
+# Documentation
+
+Run `npm run doc` on this repository to generate the [jsdoc](https://jsdoc.app/) documentation from the build,the actual files are generated in the `docs` directory.

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -1,0 +1,3 @@
+{
+    "plugins": ["plugins/markdown"]
+}

--- a/package.json
+++ b/package.json
@@ -1,10 +1,12 @@
 {
     "scripts": {
         "build": "webpack",
-        "serve": "webpack-dev-server"
+        "serve": "webpack-dev-server",
+        "doc": "jsdoc -c jsdoc.json pkg/js_chain_libs.js README.md -d docs"
     },
     "devDependencies": {
         "html-webpack-plugin": "^3.2.0",
+        "jsdoc": "~3.6.3",
         "mocha": "^6.1.4",
         "mocha-loader": "^2.0.1",
         "text-encoder": "0.0.4",


### PR DESCRIPTION
improve the code documentation, adding examples and bits of documentation taken from the "binded" code. As wasm-bindgen does already generate the jsdoc style documentation, I added a config file and a generating command, I'm not sure if there is a way to include that in a packaged version yet.