### PR TITLE
Faucet endpoint example

### DIFF
--- a/examples/faucet/README.md
+++ b/examples/faucet/README.md
@@ -1,0 +1,57 @@
+# Faucet endpoint example
+
+A minimal example of a faucet endpoint, using the sdk on nodejs, showcasing its capabilities. Allows to send a fixed amount of adas to the requested addresses.
+
+## Instructions
+
+### Install dependencies
+
+1. Build the sdk for nodejs target, in the root directory of this example run:
+
+```sh
+cd ../../ && wasm-pack build --target nodejs --out-dir ./examples/faucet/js-chain-libs/
+```
+
+2. Install the other node dependencies: `npm install`
+
+
+### Configuration
+
+The following variables can be set in file named `.env` to configure the behaviour.
+
+- JORMUNGANDR_API: The url where a jormungandr instance is listening for the rest api.
+- SECRET_KEY: The secret key of the faucet account.
+- PORT: Port to listen to for requests.
+- LOVELACES_TO_GIVE: Fixed amount of lovelaces to give at each request.
+
+For example (.env file):
+
+```plaintext
+JORMUNGANDR_API=http://localhost:8443/api/v0
+SECRET_KEY=ed25519e_sk1qp2qdlkk3qnj58es5v6wx0ngvxtg5lvyxqg255mjg04qjr7l93fxpmxlldxuu6jjghuwmfuqg3kqglghk4vk54jyfkgt3l8ttm5pgtck9yhrr
+PORT=3000
+LOVELACES_TO_GIVE=300
+```
+
+### Run the server
+
+`npm run server`
+
+### Usage example 
+
+```sh
+curl -X POST http://localhost:3000/send-money/ca1sw6gu33yw73dr60f2ehp6xemgf30r49rzc25gkrfnrfuuyf0mycgjzfvl88
+```
+
+## Offered API
+
+POST: /send-money/:destinationAddress
+
+Sends the configured amount of lovelaces to the given address.
+
+ - destinationAddress the address to send money to in string represenation
+
+## Possible improvements
+
+- Add a frontend that uses the endpoint using the sdk for address validation.
+- Better error handling.

--- a/examples/faucet/jormungandr_api.js
+++ b/examples/faucet/jormungandr_api.js
@@ -1,0 +1,25 @@
+const axios = require('axios');
+
+async function getAccountStatus(hostUrl, accountId) {
+  const response = await axios.get(`${hostUrl}/account/${accountId}`);
+  return response.data;
+}
+
+async function getNodeSettings(hostUrl) {
+  const response = await axios.get(`${hostUrl}/settings`);
+  return response.data;
+}
+
+async function postMsg(hostUrl, msg) {
+  axios.post(`${hostUrl}/message`, msg, {
+    headers: {
+      'content-type': 'application/octet-stream'
+    }
+  });
+}
+
+module.exports = {
+  getAccountStatus,
+  getNodeSettings,
+  postMsg
+};

--- a/examples/faucet/package.json
+++ b/examples/faucet/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "faucet",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "server": "node server.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "axios": "^0.19.0",
+    "fastify": "^2.6.0",
+    "fastify-env": "^1.0.1"
+  }
+}

--- a/examples/faucet/server.js
+++ b/examples/faucet/server.js
@@ -1,0 +1,151 @@
+// Require the framework and instantiate it
+/* global BigInt */
+const fastify = require('fastify')({ logger: true });
+const fastifyEnv = require('fastify-env');
+const chainLibs = require('./js-chain-libs/js_chain_libs');
+const jormungandrApi = require('./jormungandr_api');
+
+// Get config from .env file
+const schema = {
+  type: 'object',
+  required: ['JORMUNGANDR_API', 'SECRET_KEY', 'LOVELACES_TO_GIVE'],
+  properties: {
+    // The node address
+    JORMUNGANDR_API: {
+      type: 'string',
+      default: 'http://localhost:8443/api'
+    },
+    // The faucet secret key in bech32 format
+    SECRET_KEY: {
+      type: 'string'
+    },
+    // The port to listen to
+    PORT: {
+      type: 'string',
+      default: 3000
+    },
+    // Fixed amount of lovelaces to give on each request
+    LOVELACES_TO_GIVE: {
+      type: 'number',
+      default: 3000
+    }
+  }
+};
+
+const options = {
+  schema,
+  dotenv: true
+};
+
+fastify.post('/send-money/:destinationAddress', async (request, reply) => {
+  try {
+    const {
+      OutputPolicy,
+      TransactionBuilder,
+      Address,
+      Input,
+      Value,
+      Fee,
+      TransactionFinalizer,
+      Fragment,
+      PrivateKey,
+      Witness,
+      SpendingCounter,
+      Hash,
+      Account,
+      // eslint-disable-next-line camelcase
+      uint8array_to_hex
+    } = await chainLibs;
+
+    // From the settings we can get:
+    // the block0hash used for signing
+    // the transaction fees
+    const nodeSettings = await jormungandrApi.getNodeSettings(
+      fastify.config.JORMUNGANDR_API
+    );
+
+    const txbuilder = new TransactionBuilder();
+
+    const secretKey = PrivateKey.from_bech32(fastify.config.SECRET_KEY);
+    const faucetAccount = Account.from_public_key(secretKey.to_public());
+
+    // Fee (#inputs + #outputs) * coefficient + constant + #certificates*certificate
+    // #inputs = 1; #outputs = 2; #certificates = 0
+    const computedFee =
+      (1 + 1) * nodeSettings.fees.coefficient + nodeSettings.fees.constant;
+    const input = Input.from_account(
+      faucetAccount,
+      Value.from_u64(BigInt(fastify.config.LOVELACES_TO_GIVE + computedFee))
+    );
+
+    txbuilder.add_input(input);
+
+    txbuilder.add_output(
+      Address.from_string(request.params.destinationAddress),
+      Value.from_u64(BigInt(fastify.config.LOVELACES_TO_GIVE))
+    );
+
+    const feeAlgorithm = Fee.linear_fee(
+      BigInt(nodeSettings.fees.constant),
+      BigInt(nodeSettings.fees.coefficient),
+      BigInt(nodeSettings.fees.certificate)
+    );
+
+    // The amount is exact, that's why we use `forget()`
+    const finalizedTx = txbuilder.finalize(feeAlgorithm, OutputPolicy.forget());
+
+    const finalizer = new TransactionFinalizer(finalizedTx);
+
+    // To get the account counter used for signing
+    const accountStatus = await jormungandrApi.getAccountStatus(
+      fastify.config.JORMUNGANDR_API,
+      uint8array_to_hex(secretKey.to_public().as_bytes())
+    );
+
+    const witness = Witness.for_account(
+      Hash.from_hex(nodeSettings.block0Hash),
+      finalizer.get_txid(),
+      secretKey,
+      SpendingCounter.from_u32(accountStatus.counter)
+    );
+
+    finalizer.set_witness(0, witness);
+
+    const signedTx = finalizer.build();
+
+    const message = Fragment.from_generated_transaction(signedTx);
+
+    // Send the transaction
+    await jormungandrApi.postMsg(
+      fastify.config.JORMUNGANDR_API,
+      message.as_bytes()
+    );
+
+    // Return the encoded signed transaction
+    reply.send(
+      uint8array_to_hex(
+        message
+          .get_transaction()
+          .id()
+          .as_bytes()
+      )
+    );
+  } catch (err) {
+    fastify.log.error(err);
+  }
+});
+
+fastify.register(fastifyEnv, options).ready(err => {
+  if (err) fastify.log.error(err);
+  start();
+});
+
+const start = async () => {
+  try {
+    await fastify.listen(fastify.config.PORT);
+    fastify.log.info(`server listening on ${fastify.server.address().port}`);
+  } catch (err) {
+    fastify.log.error(err);
+    process.exit(1);
+  }
+};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,6 +96,10 @@ impl PublicKey {
             .map(PublicKey)
             .map_err(|_| JsValue::from_str("Malformed public key"))
     }
+
+    pub fn as_bytes(&self) -> Vec<u8> {
+        self.0.as_ref().to_vec()
+    }
 }
 
 //-----------------------------//


### PR DESCRIPTION
An example showcasing the sdk capabilities (mostly used to build the transaction). It's an account-based faucet that talks to Jormungandr via the REST API. It's a single endpoint that allows to send a fixed-amount of lovelaces to specific addresses.
It could also be extended as a tutorial, although adding a simple frontend could be useful for that.