### PR TITLE
Remove bigint usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ rust.then(mod => {
   );
   const account = Account.from_address(accountInputAddress);
 
-  const input = Input.from_account(account, Value.from_u64(BigInt(1000)));
+  const input = Input.from_account(account, Value.from_str('1000'));
 
   txbuilder.add_input(input);
 
@@ -136,16 +136,16 @@ rust.then(mod => {
     Address.from_string(
       'ca1q5nr5pvt9e5p009strshxndrsx5etcentslp2rwj6csm8sfk24a2w3swacn'
     ),
-    Value.from_u64(BigInt(500))
+    Value.from_str('500')
   );
 
   const feeAlgorithm = Fee.linear_fee(
     // constant fee
-    BigInt(20),
+    Value.from_str('20'),
     // coefficient
-    BigInt(5),
+    Value.from_str('5'),
     // certificate cost
-    BigInt(0)
+    Value.from_str('0')
   );
 
   const finalizedTx = txbuilder.finalize(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -882,6 +882,11 @@ impl Output {
     }
 }
 
+/// Type used for representing certain amount of lovelaces.
+/// It wraps an unsigned 64 bits number.
+/// Strings are used for passing to and from javascript,
+/// as the native javascript Number type can't hold the entire u64 range
+/// and BigInt is not yet implemented in all the browsers
 #[wasm_bindgen]
 #[derive(Debug, Eq, PartialEq)]
 pub struct Value(value::Value);
@@ -900,12 +905,14 @@ impl From<u64> for Value {
 
 #[wasm_bindgen]
 impl Value {
+    /// Parse the given string into a rust u64 numeric type.
     pub fn from_str(s: &str) -> Result<Value, JsValue> {
         s.parse::<u64>()
             .map_err(|e| JsValue::from_str(&format! {"{:?}", e}))
             .map(|number| number.into())
     }
 
+    /// Return the wrapped u64 formatted as a string.
     pub fn to_str(&self) -> String {
         format!("{}", self.0)
     }

--- a/tests/test_get_block_messages.js
+++ b/tests/test_get_block_messages.js
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 
-/* global BigInt */
 const rust = import('../pkg/js_chain_libs');
 
 const binaryBlock =
@@ -48,7 +47,7 @@ it('get block messages', async () => {
   expect(output.address().to_string('ca')).to.eql(
     'ca1sk6gu33yw73dr60f2ehp6xemgf30r49rzc25gkrfnrfuuyf0mycgjvef0dw'
   );
-  expect(output.value().to_number()).to.equal(BigInt(10000));
+  expect(output.value().to_str()).to.equal('10000');
 });
 
 function hexStringToBytes(string) {

--- a/tests/test_make_transaction.js
+++ b/tests/test_make_transaction.js
@@ -1,19 +1,18 @@
 import { expect } from 'chai';
 
-/* global BigInt */
 const rust = import('../pkg/js_chain_libs');
 
 const genesisHash =
   '6a702a181151b772ca0acbdc4d2870ed80c09b626b29fffc2e47abf2330ad0cd';
 const inputAccount = {
   address: 'ca1qh9u0nxmnfg7af8ycuygx57p5xgzmnmgtaeer9xun7hly6mlgt3pj2xk344',
-  value: 1000,
+  value: '1000',
   privateKey:
     'ed25519e_sk1gz0ff4w444nwejap5shxrllypz5euswq6wn04fffzes02atw99xkd4jn838v3vrfg9eqt7f4sxjlsy0tdcmj0d2dqvwc8ztwgyfnwyszvjg32'
 };
 const outputAccount = {
   address: 'ca1q5nr5pvt9e5p009strshxndrsx5etcentslp2rwj6csm8sfk24a2w3swacn',
-  value: 500
+  value: '500'
 };
 const delegation = {
   stakeKey:
@@ -49,16 +48,13 @@ it('create transaction', async () => {
   const accountAddress = Address.from_string(inputAccount.address);
   const account = Account.from_address(accountAddress);
 
-  const input = Input.from_account(
-    account,
-    Value.from_u64(BigInt(inputAccount.value))
-  );
+  const input = Input.from_account(account, Value.from_str(inputAccount.value));
 
   txbuilder.add_input(input);
 
   txbuilder.add_output(
     Address.from_string(outputAccount.address),
-    Value.from_u64(BigInt(outputAccount.value))
+    Value.from_str(outputAccount.value)
   );
 
   const certificate = Certificate.stake_delegation(
@@ -70,7 +66,11 @@ it('create transaction', async () => {
 
   txbuilder.set_certificate(certificate);
 
-  const feeAlgorithm = Fee.linear_fee(BigInt(20), BigInt(5), BigInt(10));
+  const feeAlgorithm = Fee.linear_fee(
+    Value.from_str('20'),
+    Value.from_str('5'),
+    Value.from_str('10')
+  );
 
   const finalizedTx = txbuilder.finalize(
     feeAlgorithm,

--- a/tests/test_stake_pool_registration_certificate.js
+++ b/tests/test_stake_pool_registration_certificate.js
@@ -1,17 +1,6 @@
 import { expect } from 'chai';
 
-/* global BigInt */
 const rust = import('../pkg/js_chain_libs');
-
-function bigIntToByteArray(bigInt) {
-  const bytes = [];
-  let x = bigInt;
-  for (let i = 0; i < 16; ++i) {
-    bytes.push(Number(BigInt.asUintN(8, x)));
-    x >>= BigInt(8);
-  }
-  return new Uint8Array(bytes);
-}
 
 it('generates certificate', async () => {
   const {
@@ -24,7 +13,7 @@ it('generates certificate', async () => {
     VrfPublicKey,
     PublicKeys
   } = await rust;
-  const serial = U128.from_le_bytes(bigIntToByteArray(BigInt(1010101010)));
+  const serial = U128.from_str('1010101010');
   const owners = new PublicKeys();
   owners.add(
     PublicKey.from_bech32(

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -37,7 +37,7 @@ fn parse_bech32_normal_secret_key() {
 fn mock_builder(input: u64, output: u64) -> TransactionBuilder {
     let mut txbuilder = TransactionBuilder::new();
     let txid = FragmentId::from_bytes(&[0]);
-    let utxopointer = UtxoPointer::new(txid, 0, input);
+    let utxopointer = UtxoPointer::new(txid, 0, input.into());
     let input = Input::from_utxo(&utxopointer);
 
     txbuilder.add_input(input);
@@ -45,25 +45,24 @@ fn mock_builder(input: u64, output: u64) -> TransactionBuilder {
     let output_address =
         Address::from_string("ca1qh9u0nxmnfg7af8ycuygx57p5xgzmnmgtaeer9xun7hly6mlgt3pj2xk344")
             .unwrap();
-    let value = Value::from_u64(output);
-    txbuilder.add_output(output_address, value);
+    txbuilder.add_output(output_address, output.into());
     txbuilder
 }
 
 #[wasm_bindgen_test]
 fn transaction_builder_balance() {
     let txbuilder = mock_builder(32, 20);
-    let fee_algorithm = Fee::linear_fee(2, 0, 0);
+    let fee_algorithm = Fee::linear_fee(2u64.into(), 0u64.into(), 0u64.into());
     let balance = txbuilder.get_balance(&fee_algorithm).unwrap();
 
     assert_eq!(balance.get_sign(), "positive");
-    assert_eq!(balance.get_value(), Value::from_u64(32 - 20 - 2));
+    assert_eq!(balance.get_value(), (32u64 - 20 - 2).into());
 }
 
 #[wasm_bindgen_test]
 fn transaction_builder_finalize_good_case() {
     let txbuilder = mock_builder(32, 20);
-    let fee_algorithm = Fee::linear_fee(2, 0, 0);
+    let fee_algorithm = Fee::linear_fee(2u64.into(), 0u64.into(), 0u64.into());
     let output_policy = OutputPolicy::forget();
 
     let transaction = txbuilder.finalize(&fee_algorithm, output_policy);
@@ -74,7 +73,7 @@ fn transaction_builder_finalize_good_case() {
 fn transaction_builder_finalize_not_enough_input() {
     let txbuilder = mock_builder(30, 31);
 
-    let fee_algorithm = Fee::linear_fee(2, 0, 0);
+    let fee_algorithm = Fee::linear_fee(2u64.into(), 0u64.into(), 0u64.into());
     let output_policy = OutputPolicy::forget();
 
     let transaction = txbuilder.finalize(&fee_algorithm, output_policy);


### PR DESCRIPTION
Use Value where u64 was used, and add conversions from and to strings. I actually don't understand that much the use of Value in the chain-libs, though, as it's used for some money things but not for fees and such. So it may be better to have a U64 type or something like that.