### PR TITLE
Explorer - Fix error on isBlockNumber function that was returning false positives

### DIFF
--- a/examples/explorer/src/helpers/blockHelper.js
+++ b/examples/explorer/src/helpers/blockHelper.js
@@ -1,5 +1,5 @@
-// For now, if the value is an Integer it could be a blockNumber
+// For now, if the value consists of numbers we consider it a possible blockNumber
+// as the probability of a hash being formed only by numbers is pretty low
 export const isBlockNumber = searchValue => {
-  const parsed = Number.parseInt(searchValue, 10);
-  return !Number.isNaN(parsed);
+  return /^\d+$/.test(searchValue);
 };


### PR DESCRIPTION
Fix in isBlockNumber function that was returning false positives when search values were tx hashes starting with numbers.