### PR TITLE
Add from_bytes for PublicKey and PrivateKey

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,14 +75,18 @@ impl PrivateKey {
         }
     }
 
-    pub fn from_bytes(bytes: &[u8]) -> Result<PrivateKey, JsValue> {
+    pub fn from_extended_bytes(bytes: &[u8]) -> Result<PrivateKey, JsValue> {
         crypto::SecretKey::from_binary(bytes)
             .map(key::EitherEd25519SecretKey::Extended)
-            .or_else(|_| {
-                crypto::SecretKey::from_binary(bytes).map(key::EitherEd25519SecretKey::Normal)
-            })
             .map(PrivateKey)
-            .map_err(|_| JsValue::from_str("Invalid secret key"))
+            .map_err(|_| JsValue::from_str("Invalid extended secret key"))
+    }
+
+    pub fn from_normal_bytes(bytes: &[u8]) -> Result<PrivateKey, JsValue> {
+        crypto::SecretKey::from_binary(bytes)
+            .map(key::EitherEd25519SecretKey::Normal)
+            .map(PrivateKey)
+            .map_err(|_| JsValue::from_str("Invalid normal secret key"))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,17 @@ impl PrivateKey {
             key::EitherEd25519SecretKey::Extended(ref secret) => secret.to_bech32_str(),
         }
     }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<PrivateKey, JsValue> {
+        crypto::SecretKey::from_binary(bytes)
+            .map(key::EitherEd25519SecretKey::Extended)
+            .or_else(|_| {
+                crypto::SecretKey::from_binary(bytes)
+                    .map(key::EitherEd25519SecretKey::Normal)
+            })
+            .map(PrivateKey)
+            .map_err(|_| JsValue::from_str("Invalid secret key"))
+    }
 }
 
 /// ED25519 key used as public key
@@ -102,6 +113,12 @@ impl PublicKey {
 
     pub fn as_bytes(&self) -> Vec<u8> {
         self.0.as_ref().to_vec()
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<PublicKey, JsValue> {
+        crypto::PublicKey::from_binary(bytes)
+            .map_err(|e| JsValue::from_str(&format!("{}", e)))
+            .map(PublicKey)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,8 +79,7 @@ impl PrivateKey {
         crypto::SecretKey::from_binary(bytes)
             .map(key::EitherEd25519SecretKey::Extended)
             .or_else(|_| {
-                crypto::SecretKey::from_binary(bytes)
-                    .map(key::EitherEd25519SecretKey::Normal)
+                crypto::SecretKey::from_binary(bytes).map(key::EitherEd25519SecretKey::Normal)
             })
             .map(PrivateKey)
             .map_err(|_| JsValue::from_str("Invalid secret key"))


### PR DESCRIPTION
Background: for Yoroi we need to convert our Icarus-style public & private keys to the new Shelley wrapper. To make this easy, I add a `from_bytes` function to both `PublicKey` and `PrivateKey`

Usage in Yoroi looks like this

```javascript
export function v2SkKeyToV3Key(
  v2Key: RustModule.WalletV2.PrivateKey,
): RustModule.WalletV3.PrivateKey {
  return RustModule.WalletV3.PrivateKey.from_bytes(
    // need to slice out the chain code from the extended public key
    Buffer.from(v2Key.to_hex().slice(0, 64), 'hex')
  );
}
export function v2PkKeyToV3Key(
  v2Key: RustModule.WalletV2.PublicKey,
): RustModule.WalletV3.PublicKey {
  return RustModule.WalletV3.PublicKey.from_bytes(
    // need to slice out the chain code from the extended public key
    Buffer.from(v2Key.to_hex().slice(0, 64), 'hex')
  );
}
```

Solves #52 #53 