### PR TITLE
Add Wtinesses class

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -818,6 +818,41 @@ impl AuthenticatedTransaction {
             }
         }
     }
+
+    pub fn witnesses(&self) -> Witnesses {
+        match &self.0 {
+            AuthenticatedTransactionType::NoCertificate(auth_tx) => auth_tx
+                .witnesses
+                .iter()
+                .map(|witness| Witness(witness.clone()))
+                .collect::<Vec<Witness>>()
+                .into(),
+            AuthenticatedTransactionType::PoolRegistration(auth_tx) => auth_tx
+                .witnesses
+                .iter()
+                .map(|witness| Witness(witness.clone()))
+                .collect::<Vec<Witness>>()
+                .into(),
+            AuthenticatedTransactionType::PoolManagement(auth_tx) => auth_tx
+                .witnesses
+                .iter()
+                .map(|witness| Witness(witness.clone()))
+                .collect::<Vec<Witness>>()
+                .into(),
+            AuthenticatedTransactionType::StakeDelegation(auth_tx) => auth_tx
+                .witnesses
+                .iter()
+                .map(|witness| Witness(witness.clone()))
+                .collect::<Vec<Witness>>()
+                .into(),
+            AuthenticatedTransactionType::OwnerStakeDelegation(auth_tx) => auth_tx
+                .witnesses
+                .iter()
+                .map(|witness| Witness(witness.clone()))
+                .collect::<Vec<Witness>>()
+                .into(),
+        }
+    }
 }
 
 /// Type for representing the hash of a Transaction, necessary for signing it
@@ -1408,7 +1443,14 @@ pub enum FeeVariant {
 /// It's important that witness works with opaque structures
 /// and may not know the contents of the internal transaction.
 #[wasm_bindgen]
+#[derive(Clone)]
 pub struct Witness(tx::Witness);
+
+impl From<tx::Witness> for Witness {
+    fn from(witness: tx::Witness) -> Witness {
+        Witness(witness)
+    }
+}
 
 #[wasm_bindgen]
 impl Witness {
@@ -1453,6 +1495,8 @@ impl Witness {
             .map_err(|error| JsValue::from_str(&format!("{}", error)))
     }
 }
+
+impl_collection!(Witnesses, Witness);
 
 #[wasm_bindgen]
 pub struct SpendingCounter(account::SpendingCounter);


### PR DESCRIPTION
For Yoroi we have a unittest that makes sure that the a transaction got signed by the correct keys. We do this by checking if the witness is correct.

Example usage in Yoroi
```javascript
const witnesses = signedTx.witnesses();

expect(witnesses.size()).toEqual(1);
expect(witnesses.get(0).to_bech32()).toEqual(
    'witness1q9tuk0s75d4zwahpxzydwr3dfang74s3l0l7whmx8fgjzfz28s9pnpeuhxmvu8ksa3h0hl4guhyusdaa2u93usu0vgggsqlrcswt7cq9vlq8pr'
);
```