### PR TITLE
Add sign&verify and external witnesses

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,10 @@ impl PrivateKey {
             .map(PrivateKey)
             .map_err(|_| JsValue::from_str("Invalid normal secret key"))
     }
+
+    pub fn sign(&self, message: &[u8]) -> Vec<u8> {
+        self.0.sign(&message).to_bytes()
+    }
 }
 
 /// ED25519 key used as public key

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,6 +171,10 @@ impl PublicKey {
             .map_err(|e| JsValue::from_str(&format!("{}", e)))
             .map(PublicKey)
     }
+
+    pub fn verify(&self, data: &[u8], signature: &Ed25519Signature) -> bool {
+        signature.0.verify_slice(&self.0, data) == crypto::Verification::Success
+    }
 }
 
 #[wasm_bindgen]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1478,9 +1478,7 @@ impl Witness {
     }
 
     // Witness for a utxo-based transaction generated externally (such as hardware wallets)
-    pub fn for_external_utxo(
-        witness: &UtxoWitness
-    ) -> Witness {
+    pub fn for_external_utxo(witness: &UtxoWitness) -> Witness {
         Witness(tx::Witness::Utxo(witness.0.clone()))
     }
 
@@ -1501,9 +1499,7 @@ impl Witness {
     }
 
     // Witness for a account-based transaction generated externally (such as hardware wallets)
-    pub fn for_external_account(
-        witness: &AccountWitness
-    ) -> Witness {
+    pub fn for_external_account(witness: &AccountWitness) -> Witness {
         Witness(tx::Witness::Account(witness.0.clone()))
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,9 +134,7 @@ impl PrivateKey {
     }
 
     pub fn sign(&self, message: &[u8]) -> Result<Ed25519Signature, JsValue> {
-        Ed25519Signature::from_bytes(
-            &self.0.sign(&message).to_bytes()
-        )
+        Ed25519Signature::from_bytes(&self.0.sign(&message).to_bytes())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,8 +133,8 @@ impl PrivateKey {
             .map_err(|_| JsValue::from_str("Invalid normal secret key"))
     }
 
-    pub fn sign(&self, message: &[u8]) -> Result<Ed25519Signature, JsValue> {
-        Ed25519Signature::from_bytes(&self.0.sign(&message).to_bytes())
+    pub fn sign(&self, message: &[u8]) -> Ed25519Signature {
+        Ed25519Signature(self.0.sign(&message.to_vec()))
     }
 }
 
@@ -1478,7 +1478,7 @@ impl Witness {
     }
 
     // Witness for a utxo-based transaction generated externally (such as hardware wallets)
-    pub fn for_external_utxo(witness: &UtxoWitness) -> Witness {
+    pub fn from_external_utxo(witness: &UtxoWitness) -> Witness {
         Witness(tx::Witness::Utxo(witness.0.clone()))
     }
 
@@ -1499,7 +1499,7 @@ impl Witness {
     }
 
     // Witness for a account-based transaction generated externally (such as hardware wallets)
-    pub fn for_external_account(witness: &AccountWitness) -> Witness {
+    pub fn from_external_account(witness: &AccountWitness) -> Witness {
         Witness(tx::Witness::Account(witness.0.clone()))
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,8 @@ macro_rules! impl_signature {
 }
 
 impl_signature!(Ed25519Signature, Vec<u8>, crypto::Ed25519);
+impl_signature!(AccountWitness, tx::WitnessAccountData, crypto::Ed25519);
+impl_signature!(UtxoWitness, tx::WitnessUtxoData, crypto::Ed25519);
 
 /// ED25519 signing key, either normal or extended
 #[wasm_bindgen]
@@ -1475,6 +1477,13 @@ impl Witness {
         ))
     }
 
+    // Witness for a utxo-based transaction generated externally (such as hardware wallets)
+    pub fn for_external_utxo(
+        witness: &UtxoWitness
+    ) -> Witness {
+        Witness(tx::Witness::Utxo(witness.0.clone()))
+    }
+
     /// Generate Witness for an account based transaction Input
     /// the account-spending-counter should be incremented on each transaction from this account
     pub fn for_account(
@@ -1489,6 +1498,13 @@ impl Witness {
             &account_spending_counter.0,
             &secret_key.0,
         ))
+    }
+
+    // Witness for a account-based transaction generated externally (such as hardware wallets)
+    pub fn for_external_account(
+        witness: &AccountWitness
+    ) -> Witness {
+        Witness(tx::Witness::Account(witness.0.clone()))
     }
 
     /// Get string representation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,9 +18,9 @@ use std::str::FromStr;
 use wasm_bindgen::prelude::*;
 
 macro_rules! impl_signature {
-    ($name:ident, $size:expr, $verifier_type:ty) => {
+    ($name:ident, $signee_type:ty, $verifier_type:ty) => {
         #[wasm_bindgen]
-        pub struct $name(crypto::Signature<[u8; $size], $verifier_type>);
+        pub struct $name(crypto::Signature<$signee_type, $verifier_type>);
 
         #[wasm_bindgen]
         impl $name {
@@ -37,9 +37,7 @@ macro_rules! impl_signature {
             }
 
             pub fn from_bytes(bytes: &[u8]) -> Result<$name, JsValue> {
-                let mut v = [0u8; $size];
-                v.copy_from_slice(bytes);
-                crypto::Signature::from_binary(&v)
+                crypto::Signature::from_binary(bytes)
                     .map($name)
                     .map_err(|e| JsValue::from_str(&format!("{}", e)))
             }
@@ -59,7 +57,7 @@ macro_rules! impl_signature {
     };
 }
 
-impl_signature!(Ed25519Signature, 64, crypto::Ed25519);
+impl_signature!(Ed25519Signature, Vec<u8>, crypto::Ed25519);
 
 /// ED25519 signing key, either normal or extended
 #[wasm_bindgen]


### PR DESCRIPTION
I add a `sign` function to `PrivateKey` and `verify` to `PublicKey` (this requires https://github.com/input-output-hk/chain-libs/pull/118)

I designed this so we can easily add more signature key in the future if needed.

#### Usage

```javascript

// signing test

const buff1 = Buffer.from('hello', 'utf-8');
const signature = key.sign(buff1);

// ed25519_sig1eu603zrj68h55dg9pwvmvc4wc48zy7l8m83m0fgdxekn7mx8jmvhyd3anncufde39l4vv2drpx409t2g0r7nc9m303qu06nasj3kkqqvv2xhz
console.log(signature.to_bech32());

// cf34f88872d1ef4a35050b99b662aec54e227be7d9e3b7a50d366d3f6cc796d972363d9cf1c4b7312feac629a309aaf2ad4878fd3c17717c41c7ea7d84a36b00
console.log(Buffer.from(signature.to_bytes()).toString('hex'));

// cf34f88872d1ef4a35050b99b662aec54e227be7d9e3b7a50d366d3f6cc796d972363d9cf1c4b7312feac629a309aaf2ad4878fd3c17717c41c7ea7d84a36b00
console.log(signature.to_hex());

// verify test

const pubKey = key.to_public();
const success = pubKey.verify(buff1, signature); // true as expected

const buff2 = Buffer.from('world', 'utf-8');
const failed = pubKey.verify(buff2, signature); // failed as expected
```

### Other change

I also added `AccountWitness` and `UtxoWitness` so that the WASM bindings can easily support hardware wallets in the future