### PR TITLE
Showing stake delegation alongside account info.

### DIFF
--- a/examples/wallet/app/actions/account.js
+++ b/examples/wallet/app/actions/account.js
@@ -3,17 +3,14 @@ import type {
   AppState,
   Thunk,
   AccountKeys,
-  BalanceAndCounter
+  AccountState
 } from '../reducers/types';
 import type { Amount, Address } from '../models';
 import {
   getAccountFromPrivateKey,
   buildTransaction
 } from '../utils/wasmWrapper';
-import {
-  getBalanceAndCounter,
-  broadcastTransaction
-} from '../utils/nodeConnection';
+import { getAccountState, broadcastTransaction } from '../utils/nodeConnection';
 
 export type SetKeysAction = { type: 'SET_KEYS' } & AccountKeys;
 export const SET_KEYS = 'SET_KEYS';
@@ -27,23 +24,24 @@ export function setAccount(privateKey: string): Thunk<SetKeysAction> {
           ...keys
         })
       )
-      .then(() => dispatch(updateBalanceAndCounter()));
+      .then(() => dispatch(updateAccountState()));
   };
 }
 
-export type SetBalanceAndCounterAction = {
-  type: 'SET_BALANCE_AND_COUNTER'
-} & BalanceAndCounter;
-export const SET_BALANCE_AND_COUNTER = 'SET_BALANCE_AND_COUNTER';
+export type SetAccountStateAction = {
+  type: 'SET_ACCOUNT_STATE'
+} & AccountState;
+export const SET_ACCOUNT_STATE = 'SET_ACCOUNT_STATE';
 
-export function updateBalanceAndCounter(): Thunk<SetBalanceAndCounterAction> {
-  return function updateBalanceThunk(dispatch, getState) {
-    return getBalanceAndCounter(getState().account.identifier).then(
-      ({ balance, counter }: BalanceAndCounter) =>
+export function updateAccountState(): Thunk<SetAccountState> {
+  return function updateAccountStateThunk(dispatch, getState) {
+    return getAccountState(getState().account.identifier).then(
+      ({ balance, counter, delegation }: AccountState) =>
         dispatch({
-          type: SET_BALANCE_AND_COUNTER,
+          type: SET_ACCOUNT_STATE,
           balance,
-          counter
+          counter,
+          delegation
         })
     );
   };

--- a/examples/wallet/app/components/AccountInfo.js
+++ b/examples/wallet/app/components/AccountInfo.js
@@ -1,16 +1,33 @@
 // @flow
 import React from 'react';
+import type { Account } from '../reducers/types';
 
 type Props = {
-  balance: number,
-  address: string
+  account: Account
 };
 
-export default ({ balance, address }: Props) => {
+export default ({ account }: Props) => {
   return (
     <div>
-      <p>Current Address: {address}</p>
-      <p>Balance: {balance}</p>
+      <p>Current Address: {account.address}</p>
+      <p>Balance: {account.balance}</p>
+      <table>
+        <thead>
+          <tr>
+            <th> pool id </th>
+            <th> amount </th>
+          </tr>
+        </thead>
+        <tbody>
+          {account.delegation &&
+            account.delegation.map(({ amount, poolId }) => (
+              <tr key={poolId}>
+                <td>{poolId}</td>
+                <td>{amount}</td>
+              </tr>
+            ))}
+        </tbody>
+      </table>
     </div>
   );
 };

--- a/examples/wallet/app/components/Index.js
+++ b/examples/wallet/app/components/Index.js
@@ -1,10 +1,10 @@
 // @flow
 import React from 'react';
 import { Redirect } from 'react-router';
-import { AccountState } from '../reducers/types';
+import type { Account } from '../reducers/types';
 import routes from '../constants/routes.json';
 
-export default (account: AccountState) => {
+export default (account: Account) => {
   if (!account.address) {
     return <Redirect push to={routes.INPUT_KEYS} />;
   }

--- a/examples/wallet/app/components/RefreshBalance.js
+++ b/examples/wallet/app/components/RefreshBalance.js
@@ -1,14 +1,14 @@
 // @flow
 import React from 'react';
-import typeof { updateBalanceAndCounter as UpdateBalanceAndCounter } from '../actions/account';
+import typeof { updateAccountState as UpdateAccountState } from '../actions/account';
 
 type Props = {
-  updateBalanceAndCounter: UpdateBalanceAndCounter
+  updateAccountState: UpdateAccountState
 };
 
-export default ({ updateBalanceAndCounter }: Props) => {
+export default ({ updateAccountState }: Props) => {
   return (
-    <button type="button" onClick={updateBalanceAndCounter}>
+    <button type="button" onClick={updateAccountState}>
       Refresh balance{' '}
     </button>
   );

--- a/examples/wallet/app/containers/AccountInfo.js
+++ b/examples/wallet/app/containers/AccountInfo.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import AccountInfo from '../components/AccountInfo';
 
 function mapStateToProps(state) {
-  return { balance: state.account.balance, address: state.account.address };
+  return { account: state.account };
 }
 
 export default connect(mapStateToProps)(AccountInfo);

--- a/examples/wallet/app/containers/RefreshBalance.js
+++ b/examples/wallet/app/containers/RefreshBalance.js
@@ -2,14 +2,14 @@
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import RefreshBalance from '../components/RefreshBalance';
-import { updateBalanceAndCounter } from '../actions/account';
+import { updateAccountState } from '../actions/account';
 
 function mapStateToProps() {
   return {};
 }
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators({ updateBalanceAndCounter }, dispatch);
+  return bindActionCreators({ updateAccountState }, dispatch);
 }
 
 export default connect(

--- a/examples/wallet/app/containers/Root.js
+++ b/examples/wallet/app/containers/Root.js
@@ -6,7 +6,7 @@ import { hot } from 'react-hot-loader/root';
 import config from 'config';
 import type { Store } from '../reducers/types';
 import Routes from '../Routes';
-import { updateBalanceAndCounter } from '../actions/account';
+import { updateAccountState } from '../actions/account';
 
 type Props = {
   store: Store,
@@ -20,7 +20,7 @@ const Root = ({ store, history }: Props) => {
   // connections, but in the near future we should subscribe to the gRPC gossip and
   // no longer require polling.
   setInterval(
-    () => store.dispatch(updateBalanceAndCounter()),
+    () => store.dispatch(updateAccountState()),
     config.get('pollingInterval')
   );
   return (

--- a/examples/wallet/app/models/index.js
+++ b/examples/wallet/app/models/index.js
@@ -7,3 +7,4 @@ export type Counter = number;
 export type PublicKey = string;
 export type PrivateKey = string;
 export type Identifier = string;
+export type Delegation = Array<{ poolId: string, amount: number }>;

--- a/examples/wallet/app/reducers/account.js
+++ b/examples/wallet/app/reducers/account.js
@@ -1,19 +1,20 @@
 // @flow
 import {
   SET_KEYS,
-  SET_BALANCE_AND_COUNTER,
+  SET_ACCOUNT_STATE,
   SEND_TRANSACTION
 } from '../actions/account';
 import type {
   SetKeysAction,
-  SetBalanceAndCounterAction
+  SendTransactionAction,
+  SetAccountStateAction
 } from '../actions/account';
-import type { AccountState } from './types';
+import type { Account } from './types';
 
 export default function account(
-  state: AccountState,
-  action: SetKeysAction | SetBalanceAndCounterAction
-): AccountState {
+  state: Account,
+  action: SetKeysAction | SetAccountStateAction | SendTransactionAction
+): Account {
   if (typeof state === 'undefined') {
     return {};
   }
@@ -24,10 +25,11 @@ export default function account(
         privateKey: action.privateKey,
         identifier: action.identifier
       });
-    case SET_BALANCE_AND_COUNTER:
+    case SET_ACCOUNT_STATE:
       return Object.assign({}, state, {
         balance: action.balance,
-        counter: action.counter
+        counter: action.counter,
+        delegation: action.delegation
       });
     case SEND_TRANSACTION:
       return Object.assign({}, state, {

--- a/examples/wallet/app/reducers/types.js
+++ b/examples/wallet/app/reducers/types.js
@@ -5,6 +5,7 @@ import type {
   Balance,
   Counter,
   PrivateKey,
+  Delegation,
   Identifier
 } from '../models';
 
@@ -18,11 +19,11 @@ export type Dispatch = ReduxDispatch<Action> & Thunk<Action>;
 export type Thunk<A> = ((Dispatch, ?GetState) => Promise<void> | void) => A;
 
 export type AppState = {
-  account: AccountState,
+  account: Account,
   nodeSettings: NodeSettings
 };
 
-export type AccountState = AccountKeys & BalanceAndCounter;
+export type Account = AccountKeys & AccountState;
 
 export type AccountKeys = {
   address: Address,
@@ -30,9 +31,10 @@ export type AccountKeys = {
   identifier: Identifier
 };
 
-export type BalanceAndCounter = {
+export type AccountState = {
   balance: Balance,
-  counter: Counter
+  counter: Counter,
+  delegation: Delegation
 };
 
 export type NodeSettings = {

--- a/examples/wallet/app/utils/nodeConnection.js
+++ b/examples/wallet/app/utils/nodeConnection.js
@@ -3,17 +3,22 @@ import axios from 'axios';
 import httpAdapter from 'axios/lib/adapters/http';
 import config from 'config';
 import type { Identifier } from '../models';
-import type { BalanceAndCounter, NodeSettings } from '../reducers/types';
+import type { AccountState, NodeSettings } from '../reducers/types';
 
 axios.defaults.adapter = httpAdapter;
 const BASE_URL = config.get('nodeUrl') + config.get('APIBase');
 
-export function getBalanceAndCounter(
-  identifier: Identifier
-): Promise<BalanceAndCounter> {
+export function getAccountState(identifier: Identifier): Promise<AccountState> {
   return axios
     .get(`${BASE_URL}/account/${identifier}`)
-    .then(({ data: { value, counter } }) => ({ balance: value, counter }));
+    .then(({ data: { value, counter, delegation } }) => ({
+      balance: value,
+      counter,
+      delegation: delegation.pools.map(([poolId, amount]) => ({
+        poolId,
+        amount
+      }))
+    }));
 }
 
 export function getNodeSettings(): Promise<NodeSettings> {


### PR DESCRIPTION
remaned BalanceAndCounter into AccountState (the part of the account that changes)
renamed AccountState into Account (since now the part that changes is
called AccountState)
fetching the delegation from the node alongside balance and counter
