### PR TITLE
Add clone function to Transaction

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,6 +307,13 @@ impl EitherTransaction {
         }
         .to_vec()
     }
+
+    fn clone(&self) -> EitherTransaction {
+        match &self {
+            EitherTransaction::NoCertificate(tx) => EitherTransaction::NoCertificate(tx.clone()),
+            EitherTransaction::Certificate(tx) => EitherTransaction::Certificate(tx.clone()),
+        }
+    }
 }
 
 impl From<tx::Transaction<chain_addr::Address, tx::NoExtra>> for Transaction {
@@ -374,6 +381,10 @@ impl Transaction {
             .map(|output| Output(output.clone()))
             .collect::<Vec<Output>>()
             .into()
+    }
+
+    pub fn clone(&self) -> Transaction {
+        Transaction(self.0.clone())
     }
 }
 


### PR DESCRIPTION
You may remember we had to add this functionality to the v2 WASM also a long time ago.

In Yoroi, the Flow for creating a transaction is
1) Create the transaction
2) Show it to the user and ask them to input their password
3) Attempt to sign
4) If the password is wrong return to step (2)

Note we never re-create the transaction.

This is problematic because in Rust, attempting to sign a Transaction will free the original memory (resulting in `null pointer passed to rust` if you try and sign it again).

We fix this by modifying step 3 so that it says
3) Clone the transaction and attempt to sign the clone