### PR TITLE
Always clone on WASM

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1440,7 +1440,7 @@ impl Fee {
     pub fn calculate(&self, tx: &Transaction) -> Option<Value> {
         use EitherTransaction::Certificate;
         use EitherTransaction::NoCertificate;
-        match (&self.0, tx.0.clone()) {
+        match (&self.0, &tx.0) {
             (FeeVariant::Linear(algorithm), Certificate(ref tx)) => algorithm.calculate(tx),
             (FeeVariant::Linear(algorithm), NoCertificate(ref tx)) => algorithm.calculate(tx),
         }
@@ -1581,7 +1581,7 @@ impl Fragment {
     }
 
     /// Get a Transaction if the Fragment represents one
-    pub fn get_transaction(self) -> Result<AuthenticatedTransaction, JsValue> {
+    pub fn get_transaction(&self) -> Result<AuthenticatedTransaction, JsValue> {
         match self.0.clone() {
             chain::fragment::Fragment::Transaction(auth) => {
                 Ok(AuthenticatedTransactionType::NoCertificate(auth))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,7 +202,11 @@ impl Address {
         key: &PublicKey,
         discrimination: AddressDiscrimination,
     ) -> Address {
-        chain_addr::Address(discrimination.into(), chain_addr::Kind::Single(key.0.clone())).into()
+        chain_addr::Address(
+            discrimination.into(),
+            chain_addr::Kind::Single(key.0.clone()),
+        )
+        .into()
     }
 
     /// Construct a non-account address from a pair of public keys, delegating founds from the first to the second
@@ -223,7 +227,11 @@ impl Address {
         key: &PublicKey,
         discrimination: AddressDiscrimination,
     ) -> Address {
-        chain_addr::Address(discrimination.into(), chain_addr::Kind::Account(key.0.clone())).into()
+        chain_addr::Address(
+            discrimination.into(),
+            chain_addr::Kind::Account(key.0.clone()),
+        )
+        .into()
     }
 }
 
@@ -1042,7 +1050,9 @@ impl Account {
     }
 
     pub fn from_public_key(key: &PublicKey) -> Account {
-        Account(tx::AccountIdentifier::from_single_account(key.0.clone().into()))
+        Account(tx::AccountIdentifier::from_single_account(
+            key.0.clone().into(),
+        ))
     }
 
     pub fn to_identifier(&self) -> AccountIdentifier {


### PR DESCRIPTION
Problems like https://github.com/input-output-hk/js-chain-libs/pull/75 exist multiple places in the codebase so it may be better to just systematically avoid them by making that WASM always clones its input. I think this is the best way to solve this problem because

A) Copying is relatively inexpensive (none of these are large amounts of data
B) There is no easy fix from the Javascript side because the function signatures don't tell you if a pointer will be freed when the function is called or not.

For (A) you could argue that maybe this would be problematic if some special hardware were to use these bindings. I think it still should be totally doable and so it's best to avoid premature optimization for this (much more likely that somebody accidentally frees a pointer than complains the code copies too many bytes).

For example, (before this PR) signing a transaction with a private key frees the memory for the private key (which is unexpected!). 