### PR TITLE
Wallet - use new version of chain libs

### DIFF
--- a/examples/wallet/app/actions/account.js
+++ b/examples/wallet/app/actions/account.js
@@ -15,7 +15,7 @@ import type {
 } from '../models';
 import {
   getAccountFromPrivateKey,
-  buildTransaction,
+  buildSendFundsTransaction,
   buildDelegateTransaction
 } from '../utils/wasmWrapper';
 import {
@@ -120,7 +120,7 @@ export function sendTransaction(
   // Assume balance and counter are up to date
   return function sendTransactionThunk(dispatch, getState) {
     const state: AppState = getState();
-    return buildTransaction(
+    return buildSendFundsTransaction(
       destination,
       amount,
       state.account.privateKey,

--- a/examples/wallet/app/utils/wasmWrapper.js
+++ b/examples/wallet/app/utils/wasmWrapper.js
@@ -4,13 +4,14 @@ import type { AccountKeys, NodeSettings } from '../reducers/types';
 import type {
   PoolId as InternalPoolId,
   PrivateKey as InternalPrivateKey,
-  Counter
+  Counter,
+  TransactionOutput
 } from '../models';
 import feeCalculator from './feeCalculator';
 
 const wasmBindings = import('js-chain-libs/js_chain_libs');
 export async function getAccountFromPrivateKey(
-  secret: string
+  secret: InternalPrivateKey
 ): Promise<AccountKeys> {
   const {
     PrivateKey,
@@ -44,28 +45,74 @@ export async function buildDelegateTransaction(
   nodeSettings: NodeSettings
 ): Promise<{ id: string, transaction: Uint8Array, fee: number }> {
   const {
-    OutputPolicy,
     PoolId,
+    Certificate,
+    StakeDelegation,
+    DelegationType,
+    PrivateKey,
+    PublicKey
+  } = await wasmBindings;
+  const privateKey: PrivateKey = PrivateKey.from_bech32(secret);
+  const sourcePublicKey: PublicKey = privateKey.to_public();
+  // Create certificate
+  const singlePoolDelegation: DelegationType = DelegationType.full(
+    PoolId.from_hex(poolId)
+  );
+  const certificate: Certificate = Certificate.stake_delegation(
+    StakeDelegation.new(singlePoolDelegation, sourcePublicKey)
+  );
+  return buildTransaction(secret, nodeSettings, accountCounter, certificate);
+}
+
+export async function buildSendFundsTransaction(
+  destination: string,
+  amount: number,
+  secret: InternalPrivateKey,
+  accountCounter: number,
+  nodeSettings: NodeSettings
+): Promise<{ id: string, transaction: Uint8Array, fee: number }> {
+  return buildTransaction(secret, nodeSettings, accountCounter, undefined, {
+    amount,
+    address: destination
+  });
+}
+
+async function buildTransaction(
+  secret: string,
+  nodeSettings: NodeSettings,
+  accountCounter: number,
+  certificate?: any,
+  output?: TransactionOutput
+) {
+  if (!certificate && !output) {
+    console.error(
+      'it doesnt make sense to send a transaction with only an input'
+    );
+  } else if (certificate && output) {
+    console.error(
+      'in the wallet theres no way of sending a trasaction with both an output and a certificate, this is an error'
+    );
+  }
+  const {
+    OutputPolicy,
+    Address,
     TransactionBuilder,
     InputOutput,
     InputOutputBuilder,
     Payload,
     Witnesses,
     PayloadAuthData,
-    DelegationType,
-    StakeDelegationAuthData,
-    AccountBindingSignature,
     Transaction,
     TransactionBuilderSetWitness,
     TransactionBuilderSetAuthData,
-    Certificate,
-    StakeDelegation,
+    TransactionBuilderSetIOs,
+    StakeDelegationAuthData,
+    AccountBindingSignature,
     Input,
     Value,
     Fee,
     Fragment,
     PrivateKey,
-    PublicKey,
     Witness,
     SpendingCounter,
     Hash,
@@ -75,26 +122,30 @@ export async function buildDelegateTransaction(
   } = await wasmBindings;
   const { calculateFee } = feeCalculator(nodeSettings);
   const privateKey: PrivateKey = PrivateKey.from_bech32(secret);
-  const sourcePublicKey: PublicKey = privateKey.to_public();
   const sourceAccount: Account = Account.from_public_key(
     privateKey.to_public()
   );
 
-  // 1 input + 1 certificate
-  const computedFee: number = calculateFee(1, 0, 1);
+  const computedFee: number = calculateFee(
+    1,
+    output ? 1 : 0,
+    certificate ? 1 : 0
+  );
+  const iobuilder: InputOutputBuilder = InputOutputBuilder.empty();
+  let inputAmount;
+  if (output) {
+    inputAmount = output.amount + computedFee;
+    iobuilder.add_output(
+      Address.from_string(output.address),
+      Value.from_str(output.amount.toString())
+    );
+  } else {
+    inputAmount = computedFee;
+  }
   const input: Input = Input.from_account(
     sourceAccount,
-    Value.from_str(computedFee.toString())
+    Value.from_str(inputAmount.toString())
   );
-  // Create certificate
-  const singlePoolDelegation: DelegationType = DelegationType.full(
-    PoolId.from_hex(poolId)
-  );
-  const certificate: Certificate = Certificate.stake_delegation(
-    StakeDelegation.new(singlePoolDelegation, sourcePublicKey)
-  );
-
-  const iobuilder: InputOutputBuilder = InputOutputBuilder.empty();
 
   iobuilder.add_input(input);
 
@@ -106,14 +157,21 @@ export async function buildDelegateTransaction(
 
   // The amount is exact, that's why we use `forget()`
   const IOs: InputOutput = iobuilder.seal_with_output_policy(
-    Payload.certificate(certificate),
+    certificate ? Payload.certificate(certificate) : Payload.no_payload(),
     feeAlgorithm,
     OutputPolicy.forget()
   );
 
-  const builderSetWitness: TransactionBuilderSetWitness = new TransactionBuilder()
-    .payload(certificate)
-    .set_ios(IOs.inputs(), IOs.outputs());
+  const txbuilder: TransactionBuilder = new TransactionBuilder();
+
+  const builderSetIOs: TransactionBuilderSetIOs = certificate
+    ? txbuilder.payload(certificate)
+    : txbuilder.no_payload();
+
+  const builderSetWitness: TransactionBuilderSetWitness = builderSetIOs.set_ios(
+    IOs.inputs(),
+    IOs.outputs()
+  );
 
   const witness: Witness = Witness.for_account(
     Hash.from_hex(nodeSettings.block0Hash),
@@ -128,14 +186,16 @@ export async function buildDelegateTransaction(
     witnesses
   );
 
-  const signature: PayloadAuthData = PayloadAuthData.for_stake_delegation(
-    StakeDelegationAuthData.new(
-      AccountBindingSignature.new(
-        PrivateKey.from_bech32(secret),
-        builderSignCertificate.get_auth_data()
+  const signature: PayloadAuthData = certificate
+    ? PayloadAuthData.for_stake_delegation(
+        StakeDelegationAuthData.new(
+          AccountBindingSignature.new(
+            PrivateKey.from_bech32(secret),
+            builderSignCertificate.get_auth_data()
+          )
+        )
       )
-    )
-  );
+    : PayloadAuthData.for_no_payload();
 
   const signedTx: Transaction = builderSignCertificate.set_payload_auth(
     signature
@@ -143,80 +203,6 @@ export async function buildDelegateTransaction(
 
   const message: Fragment = Fragment.from_transaction(signedTx);
 
-  return {
-    transaction: message.as_bytes(),
-    id: uint8array_to_hex(message.id().as_bytes()),
-    fee: computedFee
-  };
-}
-
-export async function buildTransaction(
-  destination: string,
-  amount: number,
-  secret: string,
-  accountCounter: number,
-  nodeSettings: NodeSettings
-): Promise<{ id: string, transaction: Uint8Array, fee: number }> {
-  const {
-    OutputPolicy,
-    TransactionBuilder,
-    Address,
-    Input,
-    Value,
-    Fee,
-    TransactionFinalizer,
-    Transaction,
-    Fragment,
-    PrivateKey,
-    PublicKey,
-    Witness,
-    SpendingCounter,
-    Hash,
-    Account,
-    // eslint-disable-next-line camelcase
-    uint8array_to_hex
-  } = await wasmBindings;
-  const { calculateFee } = feeCalculator(nodeSettings);
-  const privateKey: PrivateKey = PrivateKey.from_bech32(secret);
-  const sourcePublicKey: PublicKey = privateKey.to_public();
-  const sourceAccount: Account = Account.from_public_key(sourcePublicKey);
-
-  // 1 input + 1 output
-  const computedFee = calculateFee(1, 1, 0);
-  const inputAmount = computedFee + amount;
-  const input: Input = Input.from_account(
-    sourceAccount,
-    Value.from_str(inputAmount.toString())
-  );
-  const txbuilder: TransactionBuilder = TransactionBuilder.new_no_payload();
-  txbuilder.add_input(input);
-
-  txbuilder.add_output(
-    Address.from_string(destination),
-    Value.from_str(amount.toString())
-  );
-
-  const feeAlgorithm = Fee.linear_fee(
-    Value.from_str(nodeSettings.fees.constant.toString()),
-    Value.from_str(nodeSettings.fees.coefficient.toString()),
-    Value.from_str(nodeSettings.fees.certificate.toString())
-  );
-  // The amount is exact, that's why we use `forget()`
-  const finalizedTx: Transaction = txbuilder.seal_with_output_policy(
-    feeAlgorithm,
-    OutputPolicy.forget()
-  );
-  const finalizer: TransactionFinalizer = new TransactionFinalizer(finalizedTx);
-
-  const witness = Witness.for_account(
-    Hash.from_hex(nodeSettings.block0Hash),
-    finalizer.get_tx_sign_data_hash(),
-    privateKey,
-    SpendingCounter.from_u32(accountCounter)
-  );
-  finalizer.set_witness(0, witness);
-  const signedTx = finalizer.finalize();
-  const message: Fragment = Fragment.from_authenticated_transaction(signedTx);
   return {
     transaction: message.as_bytes(),
     id: uint8array_to_hex(message.id().as_bytes()),

--- a/examples/wallet/package.json
+++ b/examples/wallet/package.json
@@ -275,7 +275,7 @@
     "electron-updater": "4.0.6",
     "history": "4.9.0",
     "jquery": "3.4.1",
-    "js-chain-libs": "0.1.2",
+    "js-chain-libs": "0.2.0",
     "lodash": "4.17.15",
     "qrcode.react": "0.9.3",
     "react": "16.8.6",


### PR DESCRIPTION
depends on: https://github.com/input-output-hk/js-chain-libs/pull/86

the last commit refactors the wasmWrapper to avoid repetition of most of the transaction creation logic.
There are some use cases which are possible but for which we don't have a use yet (and weren't tested): sending a transaction with both a certificate and an output, and sending a transaction with only one input.
Sending a transaction with both an output and a certificate is possible and could be useful, but for now the wallet doesn't use it.