### PR TITLE
More block info

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1186,6 +1186,29 @@ impl Block {
             .collect::<Vec<Fragment>>()
             .into()
     }
+
+    pub fn epoch(&self) -> u32 {
+        self.0.date().epoch
+    }
+
+    pub fn slot(&self) -> u32 {
+        self.0.date().slot_id
+    }
+
+    pub fn chain_length(&self) -> u32 {
+        u32::from(self.0.chain_length())
+    }
+
+    pub fn leader_id(&self) -> Option<PoolId> {
+        match self.0.header.get_stakepool_id() {
+            Some(id) => Some(id.into()),
+            None => None,
+        }
+    }
+
+    pub fn content_size(&self) -> u32 {
+        self.0.header.block_content_size()
+    }
 }
 
 #[wasm_bindgen]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -437,6 +437,14 @@ impl UtxoPointer {
             value: value.0,
         })
     }
+
+    pub fn output_index(&self) -> u8 {
+        self.0.output_index
+    }
+
+    pub fn fragment_id(&self) -> FragmentId {
+        self.0.transaction_id.into()
+    }
 }
 
 /// This is either an single account or a multisig account depending on the witness type

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1208,10 +1208,7 @@ impl Block {
     }
 
     pub fn leader_id(&self) -> Option<PoolId> {
-        match self.0.header.get_stakepool_id() {
-            Some(id) => Some(id.into()),
-            None => None,
-        }
+        Some(self.0.header.get_stakepool_id()?.into())
     }
 
     pub fn content_size(&self) -> u32 {


### PR DESCRIPTION
Several basic getters for Block were added, as right now while you can
parse it from bytes, you cannot get much from it besides the
transactions within it.

UtxoPointer getters (as only Value was exposed before) were also added as they were a bit small for their own PR.

We are using this for Tangata Manu, our backend importer.