### PR TITLE
Additional functionality for reading Certificates

### DIFF
--- a/examples/wallet/app/utils/wasmWrapper.js
+++ b/examples/wallet/app/utils/wasmWrapper.js
@@ -22,7 +22,7 @@ export async function getAccountFromPrivateKey(
   } = await wasmBindings;
   const privateKey: PrivateKey = PrivateKey.from_bech32(secret);
   const publicKey: PublicKey = privateKey.to_public();
-  const account: Account = Account.from_public_key(publicKey);
+  const account: Account = Account.single_from_public_key(publicKey);
   const identifier: AccountIdentifier = account.to_identifier();
   const networkDiscrimination: AddressDiscrimination =
     config.get('networkDiscrimination') === 'testnet'
@@ -122,7 +122,7 @@ async function buildTransaction(
   } = await wasmBindings;
   const { calculateFee } = feeCalculator(nodeSettings);
   const privateKey: PrivateKey = PrivateKey.from_bech32(secret);
-  const sourceAccount: Account = Account.from_public_key(
+  const sourceAccount: Account = Account.single_from_public_key(
     privateKey.to_public()
   );
 
@@ -189,7 +189,7 @@ async function buildTransaction(
   const signature: PayloadAuthData = certificate
     ? PayloadAuthData.for_stake_delegation(
         StakeDelegationAuthData.new(
-          AccountBindingSignature.new(
+          AccountBindingSignature.new_single(
             PrivateKey.from_bech32(secret),
             builderSignCertificate.get_auth_data()
           )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -679,6 +679,12 @@ impl From<chain::certificate::StakeDelegation> for StakeDelegation {
 /// * Ratio of stake to multiple pools
 pub struct DelegationType(chain::account::DelegationType);
 
+impl From<chain::account::DelegationType> for DelegationType {
+    fn from(delegation: chain::account::DelegationType) -> DelegationType {
+        DelegationType(delegation)
+    }
+}
+
 #[wasm_bindgen]
 impl DelegationType {
     pub fn non_delegated() -> Self {
@@ -749,8 +755,74 @@ impl StakeDelegation {
         }
         .into()
     }
+
+    pub fn delegation_type(&self) -> DelegationType {
+        self.0.delegation.clone().into()
+    }
+
+    pub fn account(&self) -> AccountIdentifier {
+        AccountIdentifier(self.0.account_id.clone())
+    }
 }
 
+#[wasm_bindgen]
+pub struct OwnerStakeDelegation(chain::certificate::OwnerStakeDelegation);
+
+impl From<chain::certificate::OwnerStakeDelegation> for OwnerStakeDelegation {
+    fn from(info: chain::certificate::OwnerStakeDelegation) -> OwnerStakeDelegation {
+        OwnerStakeDelegation(info)
+    }
+}
+
+#[wasm_bindgen]
+impl OwnerStakeDelegation {
+    pub fn new(delegation_type: &DelegationType) -> OwnerStakeDelegation {
+        certificate::OwnerStakeDelegation {
+            delegation: delegation_type.0.clone(),
+        }
+        .into()
+    }
+
+    pub fn delegation_type(&self) -> DelegationType {
+        self.0.delegation.clone().into()
+    }
+}
+
+#[wasm_bindgen]
+pub struct PoolRetirement(chain::certificate::PoolRetirement);
+
+impl From<chain::certificate::PoolRetirement> for PoolRetirement {
+    fn from(retirement: chain::certificate::PoolRetirement) -> PoolRetirement {
+        PoolRetirement(retirement)
+    }
+}
+
+impl PoolRetirement {
+    pub fn new(pool_id: &PoolId, retirement_time_offset: &TimeOffsetSeconds) -> Self {
+        chain::certificate::PoolRetirement {
+            pool_id: pool_id.0.clone(),
+            retirement_time: retirement_time_offset.0,
+        }
+        .into()
+    }
+
+    pub fn pool_id(&self) -> PoolId {
+        self.0.pool_id.clone().into()
+    }
+
+    pub fn retirement_time(&self) -> TimeOffsetSeconds {
+        self.0.retirement_time.clone().into()
+    }
+}
+
+#[wasm_bindgen]
+pub enum CertificateType {
+    StakeDelegation,
+    OwnerStakeDelegation,
+    PoolRegistration,
+    PoolRetirement,
+    PoolUpdate,
+}
 #[wasm_bindgen]
 impl Certificate {
     /// Create a Certificate for StakeDelegation
@@ -762,6 +834,51 @@ impl Certificate {
     pub fn stake_pool_registration(pool_registration: PoolRegistration) -> Certificate {
         certificate::Certificate::PoolRegistration(pool_registration.0).into()
     }
+
+    /// Create a Certificate for PoolRetirement
+    pub fn stake_pool_retirement(pool_retirement: &PoolRetirement) -> Certificate {
+        certificate::Certificate::PoolRetirement(pool_retirement.0.clone()).into()
+    }
+
+    pub fn get_type(&self) -> CertificateType {
+        match &self.0 {
+            certificate::Certificate::StakeDelegation(_) => CertificateType::StakeDelegation,
+            certificate::Certificate::OwnerStakeDelegation(_) => CertificateType::OwnerStakeDelegation,
+            certificate::Certificate::PoolRegistration(_) => CertificateType::PoolRegistration,
+            certificate::Certificate::PoolRetirement(_) => CertificateType::PoolRetirement,
+            certificate::Certificate::PoolUpdate(_) => CertificateType::PoolUpdate,
+        }
+    }
+
+    pub fn get_stake_delegation(&self) -> Result<StakeDelegation, JsValue> {
+        match &self.0 {
+            certificate::Certificate::StakeDelegation(cert) => Ok(cert.clone().into()),
+            _ => Err(JsValue::from_str("Certificate is not StakeDelegation")),
+        }
+    }
+
+    pub fn get_owner_stake_delegation(&self) -> Result<OwnerStakeDelegation, JsValue> {
+        match &self.0 {
+            certificate::Certificate::OwnerStakeDelegation(cert) => Ok(cert.clone().into()),
+            _ => Err(JsValue::from_str("Certificate is not OwnerStakeDelegation")),
+        }
+    }
+
+    pub fn get_pool_registration(&self) -> Result<PoolRegistration, JsValue> {
+        match &self.0 {
+            certificate::Certificate::PoolRegistration(cert) => Ok(cert.clone().into()),
+            _ => Err(JsValue::from_str("Certificate is not PoolRegistration")),
+        }
+    }
+
+    pub fn get_pool_retirement(&self) -> Result<PoolRetirement, JsValue> {
+        match &self.0 {
+            certificate::Certificate::PoolRetirement(cert) => Ok(cert.clone().into()),
+            _ => Err(JsValue::from_str("Certificate is not PoolRetirement")),
+        }
+    }
+
+    // get_pool_update() not yet needed, implement here
 }
 
 #[wasm_bindgen]
@@ -798,6 +915,45 @@ impl PoolRegistration {
     pub fn id(&self) -> PoolId {
         self.0.to_id().into()
     }
+
+    pub fn start_validity(&self) -> TimeOffsetSeconds {
+        self.0.start_validity.into()
+    }
+
+    pub fn owners(&self) -> PublicKeys {
+        PublicKeys(self.0.owners.iter().map(|key| key.clone().into()).collect())
+    }
+
+    pub fn rewards(&self) -> TaxType {
+        self.0.rewards.into()
+    }
+}
+
+#[wasm_bindgen]
+pub struct TaxType(chain::rewards::TaxType);
+
+impl From<chain::rewards::TaxType> for TaxType {
+    fn from(inner: chain::rewards::TaxType) -> TaxType {
+        TaxType(inner)
+    }
+}
+
+impl TaxType {
+    pub fn fixed(&self) -> Value {
+        self.0.fixed.into()
+    }
+
+    pub fn ratio_numerator(&self) -> Value {
+        Value::from(self.0.ratio.numerator)
+    }
+
+    pub fn ratio_denominator(&self) -> Value {
+        Value::from(self.0.ratio.denominator.get())
+    }
+
+    pub fn max_limit(&self) -> Option<Value> {
+        Some(Value::from(self.0.max_limit?.get()))
+    }
 }
 
 #[wasm_bindgen]
@@ -818,6 +974,10 @@ impl TimeOffsetSeconds {
             .map_err(|e| JsValue::from_str(&format! {"{:?}", e}))
             .map(chain_time::DurationSeconds)
             .map(|duration| chain_time::timeline::TimeOffsetSeconds::from(duration).into())
+    }
+
+    pub fn to_string(&self) -> String {
+        format!("{}", u64::from(self.0))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -843,7 +843,9 @@ impl Certificate {
     pub fn get_type(&self) -> CertificateType {
         match &self.0 {
             certificate::Certificate::StakeDelegation(_) => CertificateType::StakeDelegation,
-            certificate::Certificate::OwnerStakeDelegation(_) => CertificateType::OwnerStakeDelegation,
+            certificate::Certificate::OwnerStakeDelegation(_) => {
+                CertificateType::OwnerStakeDelegation
+            }
             certificate::Certificate::PoolRegistration(_) => CertificateType::PoolRegistration,
             certificate::Certificate::PoolRetirement(_) => CertificateType::PoolRetirement,
             certificate::Certificate::PoolUpdate(_) => CertificateType::PoolUpdate,

--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -2,7 +2,7 @@ mod iobuilder;
 mod txbuilder;
 use super::certificate;
 use super::tx;
-use crate::{Input, Inputs, Output, Outputs, TransactionSignDataHash};
+use crate::{Certificate, Input, Inputs, Output, Outputs, TransactionSignDataHash};
 pub use iobuilder::*;
 pub use txbuilder::*;
 use wasm_bindgen::prelude::*;
@@ -52,6 +52,18 @@ impl TaggedTransaction {
     fn outputs(&self) -> Vec<tx::Output<chain_addr::Address>> {
         map_payloads!(self, tx, tx.as_slice().outputs().iter().collect())
     }
+
+    fn certificate(&self) -> Option<Certificate> {
+        Some(map_payloads!(
+            self,
+            tx,
+            tx.as_slice()
+                .payload()
+                .to_certificate_slice()?
+                .into_owned()
+                .into()
+        ))
+    }
 }
 
 impl From<tx::Transaction<tx::NoExtra>> for Transaction {
@@ -89,5 +101,10 @@ impl Transaction {
 
     pub fn clone(&self) -> Transaction {
         Transaction(self.0.clone())
+    }
+
+    // Certificate if it exists, otherwise null
+    pub fn certificate(&self) -> Option<Certificate> {
+        self.0.certificate()
     }
 }


### PR DESCRIPTION
Exposed the remaining certificate types, sans PoolUpdate, as we (Emurgo) do not need it yet.

This is being used for our backend importer Tangata Manu.