### PR TITLE
Update wallet to 0.7.0

### DIFF
--- a/examples/wallet/app/utils/wasmWrapper.js
+++ b/examples/wallet/app/utils/wasmWrapper.js
@@ -40,8 +40,8 @@ async function getAccountDataFromPrivateKey(
     AddressDiscrimination
   } = await wasmBindings;
   const publicKey: PublicKey = privateKey.to_public();
-  const account: Account = Account.from_public_key(publicKey);
   const secret = privateKey.to_bech32();
+  const account: Account = Account.single_from_public_key(publicKey);
   const identifier: AccountIdentifier = account.to_identifier();
   const networkDiscrimination: AddressDiscrimination =
     config.get('networkDiscrimination') === 'testnet'
@@ -161,7 +161,7 @@ async function buildTransaction(
   } = await wasmBindings;
   const { calculateFee } = feeCalculator(nodeSettings);
   const privateKey: PrivateKey = PrivateKey.from_bech32(secret);
-  const sourceAccount: Account = Account.from_public_key(
+  const sourceAccount: Account = Account.single_from_public_key(
     privateKey.to_public()
   );
 
@@ -228,7 +228,7 @@ async function buildTransaction(
   const signature: PayloadAuthData = certificate
     ? PayloadAuthData.for_stake_delegation(
         StakeDelegationAuthData.new(
-          AccountBindingSignature.new(
+          AccountBindingSignature.new_single(
             PrivateKey.from_bech32(secret),
             builderSignCertificate.get_auth_data()
           )

--- a/examples/wallet/package.json
+++ b/examples/wallet/package.json
@@ -276,7 +276,7 @@
     "electron-updater": "4.0.6",
     "history": "4.9.0",
     "jquery": "3.4.1",
-    "js-chain-libs": "0.2.0",
+    "js-chain-libs": "0.3.0",
     "lodash": "4.17.15",
     "qrcode.react": "0.9.3",
     "react": "16.8.6",


### PR DESCRIPTION
Update wallet to work with the changes in #96 

To merge this, a new version of the npm module after merging #96 would be needed (and the dependency must be bumped), that's the reason this is a draft.