### PR TITLE
add get witness from tx

### DIFF
--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -2,7 +2,7 @@ mod iobuilder;
 mod txbuilder;
 use super::certificate;
 use super::tx;
-use crate::{Input, Inputs, Output, Outputs, TransactionSignDataHash};
+use crate::{Input, Inputs, Output, Outputs,  Witness, Witnesses, TransactionSignDataHash};
 pub use iobuilder::*;
 pub use txbuilder::*;
 use wasm_bindgen::prelude::*;
@@ -43,6 +43,19 @@ pub enum TaggedTransaction {
 impl TaggedTransaction {
     fn id(&self) -> TransactionSignDataHash {
         map_payloads!(self, tx, tx.hash().into())
+    }
+
+    fn witnesses(&self) -> Witnesses {
+        map_payloads!(
+            self,
+            tx,
+            tx.as_slice()
+                .witnesses()
+                .iter()
+                .map(|witness| Witness(witness.clone()))
+                .collect::<Vec<Witness>>()
+                .into()
+        )
     }
 
     fn inputs(&self) -> Vec<tx::Input> {
@@ -89,5 +102,9 @@ impl Transaction {
 
     pub fn clone(&self) -> Transaction {
         Transaction(self.0.clone())
+    }
+
+    pub fn witnesses(&self) -> Witnesses {
+        self.0.witnesses()
     }
 }

--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -2,7 +2,7 @@ mod iobuilder;
 mod txbuilder;
 use super::certificate;
 use super::tx;
-use crate::{Input, Inputs, Output, Outputs,  Witness, Witnesses, TransactionSignDataHash};
+use crate::{Input, Inputs, Output, Outputs, TransactionSignDataHash, Witness, Witnesses};
 pub use iobuilder::*;
 pub use txbuilder::*;
 use wasm_bindgen::prelude::*;


### PR DESCRIPTION
I added the ability to get witnesses from the finalized transaction in https://github.com/input-output-hk/js-chain-libs/pull/55 but it seems this was removed when the transaction system was re-written. This PR adds the functionality back in again