### PR TITLE
Add from_bytes to Fragment

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1106,6 +1106,14 @@ impl Fragment {
             .map_err(|error| JsValue::from_str(&format!("{}", error)))
     }
 
+    pub fn from_bytes(bytes: Uint8Array) -> Result<Fragment, JsValue> {
+        let mut slice: Box<[u8]> = vec![0; bytes.length() as usize].into_boxed_slice();
+        bytes.copy_to(&mut *slice);
+        chain::fragment::Fragment::deserialize(&*slice)
+            .map_err(|e| JsValue::from_str(&format!("{}", e)))
+            .map(Fragment)
+    }
+
     pub fn is_initial(&self) -> bool {
         match self.0 {
             chain::fragment::Fragment::Initial(_) => true,

--- a/src/transaction/mod.rs
+++ b/src/transaction/mod.rs
@@ -11,7 +11,6 @@ use wasm_bindgen::prelude::*;
 //-------- Transaction --------------//
 //-----------------------------------//
 
-/// Type representing a unsigned transaction
 #[wasm_bindgen]
 #[derive(Clone)]
 pub struct Transaction(pub(crate) TaggedTransaction);


### PR DESCRIPTION
I need this so I can write tests that parses a Fragment created by a function and verifies the content is correct.