### PR TITLE
fix fee calculations

### DIFF
--- a/examples/wallet/config/default.json
+++ b/examples/wallet/config/default.json
@@ -10,8 +10,8 @@
   "nodeGRPCPort": "8298",
   "explorer": { "url": "http://localhost:3000", "transactionPath": "tx" },
   "fees": {
-    "certificate": 10,
-    "coefficient": 10,
+    "certificate": 0,
+    "coefficient": 0,
     "constant": 10
   },
   "APIBase": "/api/v0"


### PR DESCRIPTION
apparently certificates, outputs and inputs are free in jormungandr 0.7.1

keep in mind this is temporary, we'll call the settings REST endpoint again when we fetch real data from the gRPC API, instead of fetching the block0hash just to show we can :upside_down_face: 